### PR TITLE
feat: add Cursor Rule for generating tf tests in child modules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+concurrency:
+  group: lint-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Trunk Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Trunk Check
+        uses: trunk-io/trunk-action@v1
+        with:
+          check-mode: all

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Prettier friendly markdownlint config (all formatting rules disabled)
+extends: markdownlint/style/prettier

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,7 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,32 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version: 0.1
+cli:
+  version: 1.25.0
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.7.1
+      uri: https://github.com/trunk-io/plugins
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+runtimes:
+  enabled:
+    - node@22.16.0
+    - python@3.10.8
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - actionlint@1.7.7
+    - checkov@3.2.461
+    - git-diff-check
+    - markdownlint@0.45.0
+    - prettier@3.6.2
+    - trufflehog@3.90.4
+    - yamllint@1.37.1
+actions:
+  enabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+    - trunk-upgrade-available

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Masterpoint
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can keep it basic and copy individual Cursor Rules into projects or use `rul
 
 [`rule-tool`](https://github.com/circleci-petri/rule-tool) is a go CLI tool that generates symlinks between a centrally managed Cursor Rules repo and various projects. The advantage is that you're able to reference or pull in the same central set of Cursor Rules across multiple projects.
 
-```
+```bash
 shared-prompts/
 └── rules/
     ├── dockerfile-best-practices.mdc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
 # shared-prompts
-Open source collection of AI/LLM prompts, Cursor rules, and templates for more effective workflows.
+Masterpoint's open source collection of AI/LLM prompts, Cursor rules, and templates for more effective workflows.
+
+## How to Use
+You can keep it basic and copy individual Cursor Rules into projects or use `rule-tool` to create symlinks in multiple projects.
+
+### Using `rule-tool` to symlink Cursor Rules in repos
+
+[`rule-tool`](https://github.com/circleci-petri/rule-tool) is a go CLI tool that generates symlinks between a centrally managed Cursor Rules repo and various projects. The advantage is that you're able to reference or pull in the same central set of Cursor Rules across multiple projects.
+
+
+```
+shared-prompts/
+└── rules/
+    ├── dockerfile-best-practices.mdc
+    ├── tf-root-module-layout.mdc
+    └── tf-testing-child-module.mdc
+
+project-A/.cursorrules/
+├── tf-testing-child-module.mdc → ../../shared-prompts/rules/tf-testing-child-module.mdc
+├── tf-root-module-layout.mdc → ../../shared-prompts/rules/tf-root-module-layout.mdc
+└── ...
+
+project-B/.cursorrules/
+├── dockerfile-best-practices.mdc → ../../shared-prompts/rules/dockerfile-best-practices.mdc
+├── tf-testing-child-module.mdc → ../../shared-prompts/rules/tf-testing-child-module.mdc
+└── ...
+```
+
+To start using `rule-tool`,
+
+1. Install rule-tool following [these instructions](https://github.com/circleci-petri/rule-tool?tab=readme-ov-file#usage).
+
+2. Git clone this `shared-prompts` repo
+
+   ```bash
+   mkdir -p $HOME/tooling
+   cd $HOME/tooling
+   git clone git@github.com:masterpointio/shared-prompts.git
+   ```
+
+3. Export an env var `RULE_TOOL_PATH` that points to the shared-prompts repo,
+
+    ```bash
+    export RULE_TOOL_PATH=$HOME/tooling/shared-prompts
+    ```
+
+    You can also easily add this to your respective shell config,
+    ```bash
+    # bashrc
+    echo 'export RULE_TOOL_PATH=$HOME/tooling/shared-prompts' >> ~/.bashrc
+    
+    # zshrc
+    echo 'export RULE_TOOL_PATH=$HOME/tooling/shared-prompts' >> ~/.zshrc
+    ```
+
+   **Please note**, `rule-tool` by convention expects to find a folder named `rules` within the `RULE_TOOL_PATH` folder.
+
+4. Call `rule-tool` and symlink rules from `shared-prompts` in your current project
+
+   ```bash
+   # example project
+   cd $HOME/git/some-project
+
+   # Option 1
+   rule-tool # this will open up a terminal based GUI
+
+   # Option 2
+   # See: https://github.com/circleci-petri/rule-tool?tab=readme-ov-file#non-interactive-mode
+   rule-tool --non-interactive --list
+   ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # shared-prompts
+
 Masterpoint's open source collection of AI/LLM prompts, Cursor rules, and templates for more effective workflows.
 
 ## How to Use
+
 You can keep it basic and copy individual Cursor Rules into projects or use `rule-tool` to create symlinks in multiple projects.
 
 ### Using `rule-tool` to symlink Cursor Rules in repos
 
 [`rule-tool`](https://github.com/circleci-petri/rule-tool) is a go CLI tool that generates symlinks between a centrally managed Cursor Rules repo and various projects. The advantage is that you're able to reference or pull in the same central set of Cursor Rules across multiple projects.
-
 
 ```
 shared-prompts/
@@ -41,18 +42,19 @@ To start using `rule-tool`,
 
 3. Export an env var `RULE_TOOL_PATH` that points to the shared-prompts repo,
 
-    ```bash
-    export RULE_TOOL_PATH=$HOME/tooling/shared-prompts
-    ```
+   ```bash
+   export RULE_TOOL_PATH=$HOME/tooling/shared-prompts
+   ```
 
-    You can also easily add this to your respective shell config,
-    ```bash
-    # bashrc
-    echo 'export RULE_TOOL_PATH=$HOME/tooling/shared-prompts' >> ~/.bashrc
-    
-    # zshrc
-    echo 'export RULE_TOOL_PATH=$HOME/tooling/shared-prompts' >> ~/.zshrc
-    ```
+   You can also easily add this to your respective shell config,
+
+   ```bash
+   # bashrc
+   echo 'export RULE_TOOL_PATH=$HOME/tooling/shared-prompts' >> ~/.bashrc
+
+   # zshrc
+   echo 'export RULE_TOOL_PATH=$HOME/tooling/shared-prompts' >> ~/.zshrc
+   ```
 
    **Please note**, `rule-tool` by convention expects to find a folder named `rules` within the `RULE_TOOL_PATH` folder.
 

--- a/rules/tf-testing-child-module.mdc
+++ b/rules/tf-testing-child-module.mdc
@@ -1,0 +1,879 @@
+---
+description: Prompt to develop Terraform/OpenTofu tests for child modules
+alwaysApply: false
+---
+# Terraform/Tofu Testing Standards for Child Modules
+
+## Development process for generating quality test code
+1. Survey the terraform or tofu child module repo.
+2. Make a list of the files, and the modules/resources/locals/data in each file.
+3. First identify 2-3 easy tests to start with IF NO TESTS exist.
+4. Share back in the AI chat so your pair programming partner can direct and give feedback.
+5. If there are no tests, only add tests to a single file, and then run tofu or terraform test (ask the human for which) to ensure they work.
+6. Make small, incremental, steady code changes ensuring that the tests pass as you progressively complete work.
+7. Format the generated code after ensuring that the tests pass: `terraform fmt -recursive` or `tofu fmt -recursive`.
+
+## File Structure and Organization
+
+- Test files MUST be organized by scenario type:
+  - tests/locals.tftest.hcl - Core locals logic validation (ONLY include this file if we have local { ... } blocks in the *.tf files)
+  - tests/main.tftest.hcl - Basic happy path tests for resources and logic in main.tf
+  - tests/data.tftest.hcl - Basic happy path tests for data sources and related logic
+  - tests/*.tftest.hcl - Basic happy path tests for other *.tf files that might exist in the repo (for example, ssm.tf)
+  - tests/edge_cases.tftest.hcl - Empty inputs, missing fields, boundary conditions
+  - tests/complex_scenarios.tftest.hcl - Real-world multi-entity scenarios
+
+- Test fixtures organization:
+  - tests/fixtures/ - Directory for test fixture configurations
+  - tests/fixtures/minimal/ - Basic required configuration scenarios
+  - tests/fixtures/complex/ - Multi-entity, realistic scenarios
+  - tests/fixtures/edge_cases/ - Boundary conditions and unusual inputs
+  - Note: Keep fixtures separate from examples/ directory - examples are for documentation, fixtures are for providing data to tests
+
+- Reference existing structure: @locals.tftest.hcl, @main.tf, and other *.tf files as needed.
+
+## Test Command Strategy: Plan vs Apply
+
+### Use plan for Most Tests (Primary Focus)
+
+**Default Choice**: Use `command = plan` for the majorithy of child module tests.
+
+Plan tests validate all core module functionality without requiring actual resource creation:
+- **Module logic**: Validate locals computations, conditional logic, and data transformations
+- **Resource configuration**: Verify that resources will be created with correct attributes, tags, and settings
+- **Variable processing**: Test how input variables are transformed and applied to resources
+- **Conditional resources**: Test that resources are included/excluded based on feature flags
+- **Resource relationships**: Ensure proper key generation for for_each loops and resource dependencies
+- **Variable validations**: Test that invalid inputs are properly rejected
+
+**Benefits**: 
+- Fast execution (no provider API calls)
+- Tests module logic thoroughly
+- Works without credentials
+- Safe for CI/CD pipelines
+- Catches configuration errors early
+
+✅ DO: Use plan for logic testing (most tests)
+```hcl
+run "test_locals_logic" {
+  command = plan  # Tests our module logic
+
+  assert {
+    condition = length(local.computed_tags) == expected_count
+    error_message = "Tag computation logic failed"
+  }
+}
+```
+
+### Use apply with Mocked Providers (Limited Usage)
+
+**Exception, Not the Rule**: Use `command = apply` only for the few remaining tests when you need to test resource or module interactions that cannot be validated with plan.
+
+Apply tests should be used ONLY when:
+- **Cross-resource dependencies**: Testing that one resource's output is correctly consumed by another resource
+- **Resource ID propagation**: Verifying that resource IDs, ARNs, or computed values flow correctly between resources
+- **Module composition**: Testing how multiple modules work together in complex scenarios
+- **Provider behavior**: Testing specific provider interactions that require actual resource state
+
+**Apply tests are NOT needed for**:
+- Testing resource attributes or configurations (use plan instead)
+- Testing module logic or locals (use plan instead)
+- Testing variable validations (use plan instead)
+- Testing conditional resource creation (use plan instead)
+
+**Requirements**:
+- ALL apply tests MUST use mock providers - no real infrastructure
+- Apply tests should be minimal and focused on specific interactions
+- Most module testing should still use plan tests
+
+✅ DO: Use apply with mocked providers for integration testing
+```hcl
+run "test_complete_infrastructure_integration" {
+  command = apply  # Uses mocked providers only
+  
+  mock_provider "aws" {
+    mock_data "aws_caller_identity" {
+      defaults = { account_id = "123456789012" }
+    }
+    mock_resource "aws_vpc" {
+      defaults = { id = "vpc-mock123" }
+    }
+    mock_resource "aws_security_group" {
+      defaults = { id = "sg-mock123" }
+    }
+    mock_resource "aws_instance" {
+      defaults = { 
+        id = "i-mock123"
+        private_ip = "10.0.1.100"
+      }
+    }
+  }
+
+  variables {
+    vpc_id = "vpc-mock123"
+    instance_type = "t3.micro"
+    environment = "production"
+    enable_monitoring = true
+  }
+
+  # Test resource creation and interdependencies
+  assert {
+    condition = aws_instance.main.vpc_security_group_ids[0] == aws_security_group.main.id
+    error_message = "Instance should reference the created security group"
+  }
+
+  assert {
+    condition = aws_cloudwatch_log_group.monitoring[0].name == "/aws/ec2/${aws_instance.main.id}"
+    error_message = "Log group should be created with instance ID when monitoring enabled"
+  }
+
+  # Test that enabling monitoring creates all expected resources
+  assert {
+    condition = length(aws_cloudwatch_log_group.monitoring) == 1
+    error_message = "Monitoring should create log group when enabled"
+  }
+}
+```
+
+## Testing Requirements for Local Variables
+When analyzing `@locals.tf` or `locals {}` blocks, focus on testing **crucial transformations and computations** that contain important business logic.
+
+### Testing Strategy
+
+**Identify Critical Operations**: Test locals that:
+- Drive resource creation decisions (enable/disable logic)
+- Transform user inputs (list-to-map, filtering, merging)
+- Generate resource keys for `for_each` loops
+- Contain conditional logic with multiple branches
+
+### Core Test Patterns
+
+✅ DO: Test conditional logic
+```hcl
+run "test_instance_sizing_logic" {
+  command = plan
+  
+  variables {
+    environment = "production"
+    workload_type = "compute-heavy"
+  }
+
+  assert {
+    condition = local.instance_type == "c5.2xlarge"
+    error_message = "Production compute-heavy workloads should use c5.2xlarge"
+  }
+}
+```
+
+✅ DO: Test enabled/disabled features
+```hcl
+run "test_monitoring_disabled" {
+  command = plan
+
+  variables {
+    enable_monitoring = false
+  }
+
+  assert {
+    condition = local.monitoring_config == null
+    error_message = "Monitoring config should be null when disabled"
+  }
+}
+```
+
+✅ DO: Test data transformations
+```hcl
+run "test_user_role_mapping" {
+  command = plan
+
+  variables {
+    user_list = ["alice", "bob", "charlie"]
+    admin_users = ["alice"]
+    default_role = "viewer"
+  }
+
+  assert {
+    condition = local.user_roles["alice"] == "admin"
+    error_message = "Alice should be assigned admin role"
+  }
+
+  assert {
+    condition = local.user_roles["bob"] == "viewer" && local.user_roles["charlie"] == "viewer"
+    error_message = "Bob and Charlie should be assigned default viewer role"
+  }
+
+  assert {
+    condition = length(keys(local.user_roles)) == 3
+    error_message = "All users should be included in role mapping"
+  }
+}
+```
+
+✅ DO: Test merging operations
+```hcl
+run "test_tag_merging" {
+  command = plan
+
+  variables {
+    common_tags = { Environment = "prod" }
+    additional_tags = { Project = "web-app" }
+  }
+
+  assert {
+    condition = local.merged_tags["Environment"] == "prod"
+    error_message = "Common tags should be preserved"
+  }
+
+  assert {
+    condition = can(local.merged_tags["Name"])
+    error_message = "Default Name tag should be generated"
+  }
+}
+```
+
+### Testing Priorities
+
+**High Priority**: Conditional logic, enable/disable flags, data transformations for `for_each`
+**Medium Priority**: Complex string operations, filtering logic
+**Low Priority**: Simple passthrough or static assignments
+
+## Testing Requirements for Variable Validations
+When analyzing `@variables.tf`, identify and test validation blocks that enforce critical business rules and data integrity. Variable validations are crucial safeguards that prevent invalid configurations from reaching resources.
+
+#### Validation Testing Strategy
+
+**High-Priority Validations to Test**:
+1. **Format Validations**: Email addresses, URLs, ARNs, patterns using `regex()` or `can()`
+2. **Enum/Choice Validations**: Fields with restricted sets of allowed values using `contains()`
+3. **Cross-Field Dependencies**: Validations where multiple fields must be compatible
+4. **Complex Nested Validations**: Multi-level loops through lists and maps
+5. **Length and Range Constraints**: String lengths, numeric ranges, collection sizes
+6. **Provider-Specific Requirements**: JSON encoding, specific formats required by APIs
+
+#### Core Validation Test Patterns
+
+✅ DO: Test regex format validations (emails, domains, patterns)
+```hcl
+run "test_email_validation_success" {
+  command = plan
+
+  variables {
+    users = {
+      "user1" = {
+        primary_email = "valid.user@example.com"
+        family_name = "Doe"
+        given_name = "John"
+      }
+    }
+  }
+
+  assert {
+    condition = length(var.users) == 1
+    error_message = "Valid email should pass validation"
+  }
+}
+
+run "test_email_validation_failure" {
+  command = plan
+
+  variables {
+    users = {
+      "user1" = {
+        primary_email = "invalid-email"
+        family_name = "Doe"
+        given_name = "John"
+      }
+    }
+  }
+
+  expect_failures = [var.users]
+}
+```
+
+✅ DO: Test enum/choice validations with contains()
+```hcl
+run "test_role_validation_success" {
+  command = plan
+
+  variables {
+    users = [
+      {
+        email = "user@example.com"
+        name = "Test User"
+        roles = ["standard", "admin"]
+        username = "testuser"
+      }
+    ]
+  }
+
+  assert {
+    condition = length(var.users) == 1
+    error_message = "Valid roles should pass validation"
+  }
+}
+
+run "test_role_validation_failure" {
+  command = plan
+
+  variables {
+    users = [
+      {
+        email = "user@example.com"
+        name = "Test User"
+        roles = ["invalid_role"]
+        username = "testuser"
+      }
+    ]
+  }
+
+  expect_failures = [var.users]
+}
+```
+
+✅ DO: Test conditional requirement validations
+```hcl
+run "test_conditional_requirement_valid" {
+  command = plan
+
+  variables {
+    resources = [
+      {
+        name = "prod-database"
+        environment = "production"
+        backup_enabled = true
+        backup_schedule = "0 2 * * *"  # Required when backup_enabled = true
+      }
+    ]
+  }
+
+  assert {
+    condition = length(var.resources) == 1
+    error_message = "Backup schedule should be required when backup is enabled"
+  }
+}
+
+run "test_conditional_requirement_invalid" {
+  command = plan
+
+  variables {
+    resources = [
+      {
+        name = "prod-database"
+        environment = "production"
+        backup_enabled = true
+        backup_schedule = null  # Invalid: required when backup_enabled = true
+      }
+    ]
+  }
+
+  expect_failures = [var.resources]
+}
+```
+
+#### Validation Testing Guidelines
+
+**Test Both Success and Failure Cases**:
+- **Success Tests**: Verify that valid inputs pass validation
+- **Failure Tests**: Use `expect_failures = [var.variable_name]` to ensure invalid inputs are properly rejected
+
+**Focus on Edge Cases**:
+- Boundary values (minimum/maximum lengths, edge of numeric ranges)
+- Empty or null values where applicable
+- Special characters in string validations
+- Mixed case sensitivity in enum validations
+
+**Complex Validation Patterns**:
+- **Flattened Collections**: Test validations that use `flatten()` to check nested lists
+- **Conditional Logic**: Test validations with null checks and conditional expressions
+- **Multiple Validation Blocks**: Ensure all validation rules work together correctly
+
+#### Testing Priorities for Variable Validations
+
+**High Priority**: Email/URL regex patterns, enum values, cross-field dependencies, provider API requirements. If there is a tofu or terraform specific MCP setup, use this to get specific details on provider API requirements.
+**Medium Priority**: Length constraints, numeric ranges, nested object validations
+**Low Priority**: Simple type validations, basic string patterns
+
+
+
+## Testing Requirements for Happy Path Resources
+When analyzing `@main.tf`, `@data.tf`, and other `*.tf` files, focus on testing **core module functionality** and **straightforward expected use cases** without complex edge cases or advanced scenarios.
+
+### Testing Strategy
+
+**Primary Focus**: Test basic resource creation and configuration using standard, realistic inputs that represent common deployment scenarios.
+
+**Core Areas to Test**:
+- Minimal viable configurations with only required variables
+- Resource attribute verification and direct variable-to-resource mapping
+- Simple conditional logic for enabled/disabled features
+- Basic resource relationships and dependencies
+- Standard Terraform behaviors (`dynamic` blocks, `for_each`, `count`)
+
+**File Organization**:
+- **`tests/main.tftest.hcl`** - Primary happy path tests for resources and logic in `main.tf`
+- **`tests/data.tftest.hcl`** - Happy path tests for data sources and related logic  
+- **`tests/*.tftest.hcl`** - Happy path tests for other `*.tf` files (e.g., `tests/ssm.tftest.hcl` for `ssm.tf`)
+
+### Core Test Patterns
+
+✅ DO: Test variable type handling
+```hcl 
+run "test_variable_types" {
+  command = plan
+
+  variables {
+    vpc_id          = "vpc-12345678"           # string
+    subnet_ids      = ["subnet-1", "subnet-2"] # list
+    tags            = { Environment = "test" }  # map
+    instance_count  = 2                        # number
+    enable_feature  = true                     # bool
+  }
+
+  assert {
+    condition     = length(aws_instance.main) > 0
+    error_message = "Module should create resources when provided with valid inputs"
+  }
+}
+```
+
+✅ DO: Test basic resource creation
+```
+run "test_basic_resource_creation" {
+  command = plan
+
+  variables {
+    vpc_id = "vpc-12345678"
+    name   = "test-instance"
+  }
+
+  assert {
+    condition     = aws_instance.main.vpc_id == "vpc-12345678"
+    error_message = "Instance should be created in the specified VPC"
+  }
+
+  assert {
+    condition     = length(aws_instance.main.tags) > 0
+    error_message = "Instance should have tags applied"
+  }
+}
+
+✅ DO: Test resource attribute assignment
+```hcl
+run "test_resource_configuration" {
+  command = plan
+
+  variables {
+    vpc_id        = "vpc-12345678"
+    instance_type = "t3.micro"
+    environment   = "development"
+  }
+
+  assert {
+    condition     = aws_instance.main.instance_type == var.instance_type
+    error_message = "Instance type should match input variable"
+  }
+
+  assert {
+    condition     = length(aws_instance.main.vpc_security_group_ids) > 0
+    error_message = "Instance should have security groups assigned"
+  }
+}
+```
+
+✅ DO: Test conditional logic
+```hcl
+run "test_conditional_resource_creation" {
+  command = plan
+
+  variables {
+    vpc_id              = "vpc-12345678"
+    create_load_balancer = true
+    environment         = "production"
+  }
+
+  assert {
+    condition     = aws_lb.main[0].load_balancer_type == "application"
+    error_message = "Load balancer should be created when enabled"
+  }
+
+  assert {
+    condition     = length(aws_lb.main) == 1
+    error_message = "Exactly one load balancer should be created when enabled"
+  }
+}
+```
+
+✅ DO: Test for_each and count logic
+```hcl
+run "test_multiple_resource_creation" {
+  command = plan
+
+  variables {
+    vpc_id     = "vpc-12345678"
+    subnet_ids = ["subnet-1", "subnet-2", "subnet-3"]
+  }
+
+  assert {
+    condition     = length(aws_route_table_association.main) == 3
+    error_message = "Should create route table association for each subnet"
+  }
+
+  assert {
+    condition     = contains(keys(aws_route_table_association.main), "subnet-1")
+    error_message = "Route table associations should use subnet IDs as keys"
+  }
+}
+```
+
+✅ DO: Test dynamic blocks
+```hcl
+run "test_dynamic_block_configuration" {
+  command = plan
+
+  variables {
+    vpc_id = "vpc-12345678"
+    security_group_rules = [
+      {
+        type        = "ingress"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+      },
+      {
+        type        = "ingress"
+        from_port   = 443
+        to_port     = 443
+        protocol    = "tcp"
+        cidr_blocks = ["10.0.0.0/8"]
+      }
+    ]
+  }
+
+  assert {
+    condition     = length(aws_security_group.main.ingress) == 2
+    error_message = "Security group should have 2 ingress rules from dynamic block"
+  }
+
+  assert {
+    condition     = contains([for rule in aws_security_group.main.ingress : rule.from_port], 80)
+    error_message = "Security group should include port 80 rule"
+  }
+
+  assert {
+    condition     = contains([for rule in aws_security_group.main.ingress : rule.from_port], 443)
+    error_message = "Security group should include port 443 rule"
+  }
+}
+```
+
+### Testing Priorities
+
+**High Priority**: Basic resource creation, variable-to-resource mapping, conditional resource logic, `for_each`/`count` behaviors
+**Medium Priority**: Dynamic blocks, simple resource relationships, tag application
+**Low Priority**: Resource defaults, simple passthrough configurations
+
+## Testing Requirements for Edge Cases
+When analyzing module configurations, focus on testing **common mistakes and boundary conditions** that engineers encounter in real-world scenarios.
+
+### Testing Strategy
+
+**Primary Focus**: Test scenarios that represent realistic user errors, input formatting inconsistencies, and boundary conditions that modules should handle gracefully.
+
+**Core Areas to Test**:
+- Common engineer mistakes and "fat finger" scenarios
+- Mixed data edge cases (single-item collections, empty collections)
+- Input formatting inconsistencies (hyphenated vs underscore naming, mixed case)
+- Default value behavior when optional variables are omitted
+- Expected validation failures for invalid inputs
+
+### Core Test Patterns
+
+✅ DO: Test mixed case and formatting inconsistencies
+```hcl
+run "test_mixed_case_resource_names" {
+  command = plan
+
+  variables {
+    vpc_id          = "vpc-12345678"
+    environment     = "Production"  # Mixed case - common mistake
+    project_name    = "Web-App"     # Hyphenated - may break some naming
+    owner_team      = "PLATFORM"   # All caps - may not match expected patterns
+  }
+
+  assert {
+    condition     = can(regex("^[a-z0-9-]+$", local.normalized_name))
+    error_message = "Module should normalize mixed case inputs to lowercase"
+  }
+
+  assert {
+    condition     = aws_instance.main.tags["Environment"] == "production"
+    error_message = "Environment tag should be normalized to lowercase"
+  }
+}
+
+✅ DO: Test single-item collections and empty collections
+```hcl
+run "test_single_item_and_empty_collections" {
+  command = plan
+
+  variables {
+    vpc_id              = "vpc-12345678"
+    subnet_ids          = ["subnet-12345678"]        # Single item - common edge case
+    security_group_ids  = []                         # Empty - should use defaults
+    additional_tags     = { "SingleTag" = "value" }  # Single tag instead of multiple
+  }
+
+  assert {
+    condition     = length(aws_instance.main.subnet_id) == 1
+    error_message = "Module should handle single-subnet deployments"
+  }
+
+  assert {
+    condition     = length(aws_instance.main.vpc_security_group_ids) > 0
+    error_message = "Module should create default security groups when none provided"
+  }
+
+  assert {
+    condition     = contains(keys(aws_instance.main.tags), "SingleTag")
+    error_message = "Module should preserve single additional tags"
+  }
+}
+```
+
+✅ DO: Test expected validation failures
+```hcl
+run "test_invalid_vpc_id_format_fails" {
+  command = plan
+
+  variables {
+    vpc_id = "invalid-vpc-format"  # Should fail VPC ID validation
+    name   = "test-instance"
+  }
+
+  expect_failures = [var.vpc_id]
+}
+
+run "test_empty_required_name_fails" {
+  command = plan
+
+  variables {
+    vpc_id = "vpc-12345678"
+    name   = ""  # Empty string should fail validation
+  }
+
+  expect_failures = [var.name]
+}
+```
+
+### Testing Priorities
+
+**High Priority**: Common formatting mistakes, single-item collections, validation failures, default value handling
+**Medium Priority**: Mixed case normalization, empty collections, boundary conditions
+**Low Priority**: Unusual input combinations, rarely-used edge cases
+
+## Testing Requirements for Complex Scenarios
+When analyzing multi-resource modules, focus on testing **realistic production deployments** with cross-resource dependencies and multi-provider integrations.
+
+### Testing Strategy
+
+**Primary Focus**: Test complex, realistic scenarios that represent actual production deployments with multiple interconnected resources and external service integrations.
+
+**Core Areas to Test**:
+- Cross-resource dependencies and resource relationship chains
+- Multi-provider integration with external services
+- Production-like configurations (multi-AZ, scaling, redundancy)
+- Compliance requirements and complex tagging strategies
+- Resource interdependencies and proper ID propagation
+
+### Core Test Patterns
+
+✅ DO: Test cross-resource dependencies with realistic production setup
+```hcl
+run "test_production_web_application_stack" {
+  command = plan
+
+  variables {
+    # Network Configuration
+    vpc_id                    = "vpc-12345678"
+    public_subnet_ids         = ["subnet-12345678", "subnet-87654321"]
+    private_subnet_ids        = ["subnet-11111111", "subnet-22222222"]
+    
+    # Application Configuration
+    environment              = "production"
+    application_name         = "web-api"
+    instance_types           = {
+      web = "t3.large"
+      api = "c5.xlarge"
+    }
+    
+    # Scaling and Redundancy
+    min_capacity             = 2
+    max_capacity             = 10
+    desired_capacity         = 4
+    multi_az_enabled         = true
+    
+    # Security and Compliance
+    enable_waf               = true
+    enable_cloudtrail        = true
+    encryption_at_rest       = true
+    compliance_tags          = {
+      "CostCenter"     = "Engineering"
+      "DataClass"      = "Internal"
+      "Compliance"     = "SOC2"
+      "BackupRequired" = "true"
+    }
+    
+    # External Integrations
+    monitoring_endpoints     = ["https://api.datadog.com", "https://hooks.slack.com/services/xxx"]
+    dns_zone_id             = "Z1234567890"
+    certificate_domain      = "api.company.com"
+  }
+
+  # Test complex resource interdependencies
+  assert {
+    condition     = aws_lb.main.security_groups[0] == aws_security_group.alb.id
+    error_message = "Load balancer should reference the ALB security group"
+  }
+
+  assert {
+    condition     = aws_autoscaling_group.main.target_group_arns[0] == aws_lb_target_group.main.arn
+    error_message = "Auto scaling group should be attached to load balancer target group"
+  }
+
+  assert {
+    condition     = length(aws_instance.main) >= var.min_capacity
+    error_message = "Should create at least minimum required instances"
+  }
+
+  # Test multi-AZ distribution
+  assert {
+    condition     = length(distinct([for instance in aws_instance.main : instance.availability_zone])) > 1
+    error_message = "Instances should be distributed across multiple availability zones"
+  }
+
+  # Test compliance tagging
+  assert {
+    condition     = contains(keys(aws_instance.main[0].tags), "DataClass")
+    error_message = "All instances should have compliance tags applied"
+  }
+}
+```
+
+✅ DO: Test multi-provider integration scenario
+```hcl
+run "test_aws_with_external_monitoring_integration" {
+  command = plan
+
+  mock_provider "aws" {
+    mock_data "aws_caller_identity" {
+      defaults = { account_id = "123456789012" }
+    }
+    mock_resource "aws_instance" {
+      defaults = { 
+        id = "i-1234567890abcdef0"
+        private_ip = "10.0.1.100"
+      }
+    }
+  }
+
+  mock_provider "datadog" {
+    mock_resource "datadog_monitor" {
+      defaults = { id = "12345678" }
+    }
+  }
+
+  variables {
+    # AWS Infrastructure
+    vpc_id                   = "vpc-12345678"
+    subnet_ids               = ["subnet-12345678", "subnet-87654321"]
+    instance_type            = "t3.medium"
+    
+    # External Service Integration
+    enable_datadog_monitoring = true
+    datadog_api_key          = "test-api-key"
+    monitoring_thresholds    = {
+      cpu_high    = 80
+      memory_high = 85
+      disk_high   = 90
+    }
+    
+    # DNS and SSL
+    domain_name              = "app.company.com"
+    enable_ssl               = true
+    
+    # Backup and DR
+    backup_schedule          = "0 2 * * *"
+    cross_region_backup      = true
+    dr_region               = "us-west-2"
+  }
+
+  # Test AWS resource creation
+  assert {
+    condition     = aws_instance.main.instance_type == "t3.medium"
+    error_message = "AWS instance should be created with specified type"
+  }
+
+  # Test external monitoring integration
+  assert {
+    condition     = datadog_monitor.cpu_monitor.thresholds.critical == 80
+    error_message = "Datadog monitor should use configured CPU threshold"
+  }
+
+  # Test cross-service resource references
+  assert {
+    condition     = datadog_monitor.instance_monitor.query == "avg:system.cpu.user{host:${aws_instance.main.id}}"
+    error_message = "Datadog monitor should reference AWS instance ID"
+  }
+ }
+```
+
+### Testing Priorities
+
+**High Priority**: Cross-resource dependencies, multi-AZ deployments, resource ID propagation, compliance tagging
+**Medium Priority**: Multi-provider integration, scaling scenarios, complex conditional logic
+**Low Priority**: Advanced configurations, rarely-used provider features
+
+
+
+
+## Mock Provider Configuration (REQUIRED)
+- ALL tests MUST use mock providers - no exceptions
+- Apply tests will fail without mock provider definitions
+- Plan tests should include mocks for consistency
+
+### Examples of mocked providers
+
+Example of mocked AWS provider
+```hcl
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = { name = "us-east-1" }
+  }
+  mock_data "aws_ami" {
+    defaults = { id = "ami-12345678" } # ONLY if you need an aws_ami
+  }
+  mock_data "aws_caller_identity" {
+    defaults = { account_id = "123456789012" }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
+    }
+  }
+  mock_resource "aws_launch_template" {
+    defaults = {
+      id = "lt-mock123456789" # ONLY if you need an aws_launch_template
+    }
+  }
+}
+```
+
+Example of mocked Tailscale provider
+```hcl
+mock_provider "tailscale" {
+  mock_resource "tailscale_tailnet_key" {
+    defaults = { key = "tskey-test-123456789" }
+  }
+}
+```


### PR DESCRIPTION
## what
- feat: add Cursor Rule for generating tf tests in child modules)
- docs: Add LICENSE file
- docs: Update readme with quick intro to using rule-tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated README with refreshed branding and step‑by‑step instructions for using a CLI to symlink shared rules across repositories.
  - Added a comprehensive guide for testing Terraform/Tofu child modules covering test structure, fixtures, plan‑first strategy, mock providers, validation patterns, and CI best practices.
- Chores
  - Added the Apache 2.0 license.
  - Added a linting workflow and repository tooling/configuration plus ignore rules to support consistent linting and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->